### PR TITLE
docs: provides documentation for AWS deployment strategy [#50]

### DIFF
--- a/.markdownlint.rb
+++ b/.markdownlint.rb
@@ -1,2 +1,2 @@
 all
-rule 'MD013', :line_length => 120, :ignore_code_blocks => true
+rule 'MD013', :line_length => 120, :ignore_code_blocks => true, :tables => false

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -4,3 +4,4 @@ default: true
 MD013:
   line_length: 120
   code_blocks: false
+  tables: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,13 @@ repos:
     hooks:
       - id: pyupgrade
 
+  # unicode character normalization
+  - repo: https://github.com/sirosen/texthooks
+    rev: 0.7.1
+    hooks:
+      - id: fix-smartquotes
+      - id: fix-unicode-dashes
+
   # markdown linting
   - repo: https://github.com/markdownlint/markdownlint
     rev: v0.13.0  # NOTE: v0.15.0 is giving a headache with pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ cd Course-Enrollment-App
 ## Environment Variables
 
 The app requires a `SECRET_KEY` environment variable to be set before starting.
-This key is used by Flask for session signing and CSRF protection — it must be
+This key is used by Flask for session signing and CSRF protection -- it must be
 a strong random value and must **not** be hardcoded or committed to source control.
 
 Run the setup command to generate a `.env` file with a fresh key automatically:
@@ -55,7 +55,7 @@ SECRET_KEY=<randomly generated value>
 ```
 
 Docker Compose automatically loads `.env`, so `make run` will pick it up.
-If `.env` already exists, `make setup` is a no-op — delete the file first to
+If `.env` already exists, `make setup` is a no-op -- delete the file first to
 regenerate.
 
 ## Virtual Environment

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ## Generate .env with a random SECRET_KEY (skips if .env already exists)
 setup:
 	@if [ -f .env ]; then \
-		echo ".env already exists — skipping. Delete it first to regenerate."; \
+		echo ".env already exists -- skipping. Delete it first to regenerate."; \
 	else \
 		echo "SECRET_KEY=$$(python3 -c 'import secrets; print(secrets.token_hex(32))')" > .env; \
 		echo ".env created with a fresh SECRET_KEY."; \

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ For full details, see [TESTING.md](TESTING.md).
 
 ## Features
 
-- **User registration & login** — session-based auth with hashed passwords (Werkzeug)
-- **Course catalog** — browse courses pulled from MongoDB, filterable by term
-- **Course enrollment** — enroll in courses with duplicate-enrollment protection, CSRF-protected form
-- **Enrollment dashboard** — view your enrolled courses via MongoDB aggregation
-- **REST API** — authenticated course endpoints at `/api/v1/courses` with Swagger UI docs (flask-restx)
-- **Dockerized stack** — Flask, MongoDB, and seed data orchestrated via Docker Compose
-- **CI/CD** — GitHub Actions workflows with pre-commit linting (flake8, markdownlint)
+- **User registration & login** -- session-based auth with hashed passwords (Werkzeug)
+- **Course catalog** -- browse courses pulled from MongoDB, filterable by term
+- **Course enrollment** -- enroll in courses with duplicate-enrollment protection, CSRF-protected form
+- **Enrollment dashboard** -- view your enrolled courses via MongoDB aggregation
+- **REST API** -- authenticated course endpoints at `/api/v1/courses` with Swagger UI docs (flask-restx)
+- **Dockerized stack** -- Flask, MongoDB, and seed data orchestrated via Docker Compose
+- **CI/CD** -- GitHub Actions workflows with pre-commit linting (flake8, markdownlint)
 
 Please see [the testing documentation](TESTING.md) that showcases an end-to-end demo of features supported.
 

--- a/application/README.md
+++ b/application/README.md
@@ -2,7 +2,7 @@
 
 The Flask app follows a single-module structure:
 
-- **routes.py** — Web routes and REST API endpoints (flask-restx)
-- **models.py** — MongoEngine document models (User, Course, Enrollment)
-- **forms.py** — WTForms classes for login and registration
-- **templates/** — Jinja2 HTML templates with Bootstrap 5
+- **routes.py** -- Web routes and REST API endpoints (flask-restx)
+- **models.py** -- MongoEngine document models (User, Course, Enrollment)
+- **forms.py** -- WTForms classes for login and registration
+- **templates/** -- Jinja2 HTML templates with Bootstrap 5

--- a/application/templates/index.html
+++ b/application/templates/index.html
@@ -6,7 +6,7 @@
         <div class="col-md-8 offset-md-2 text-center">
             <h1>Welcome to Network Operations University.</h1>
             <p class="lead mt-3">
-                Browse our course catalog, enroll in classes, and manage your schedule — all in one place.
+                Browse our course catalog, enroll in classes, and manage your schedule -- all in one place.
             </p>
 
             {% if session["username"] %}

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,4 +1,4 @@
-# AWS Architecture -- Course Enrollment App
+# AWS Architecture for the Course Enrollment App
 
 This document is the single source of truth for the AWS deployment design of the Course Enrollment App.
 It captures architecture decisions, the system diagram, cost estimates, and the release strategy.
@@ -13,7 +13,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | ECS Fargate |
 | **Alternatives considered** | EC2, EKS, App Runner |
-| **Rationale** | Serverless containers -- no EC2 patching, scales to zero when desired count is set to 0 (ideal for demo/cost control), and is the cheapest managed container option at this scale. |
+| **Rationale** | ECS Fargate is a serverless container runtime -- AWS manages the underlying EC2 fleet, eliminating OS patching and capacity planning. Tasks can scale to zero by setting the desired count to 0, reducing cost to ~$0 when not demoing. See the [ECS launch type comparison](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) and [Fargate pricing](https://aws.amazon.com/fargate/pricing/). EKS adds Kubernetes complexity with no benefit at this scale; App Runner is simpler but less configurable for custom networking. |
 
 ---
 
@@ -23,7 +23,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | MongoDB Atlas M0 (free cluster) |
 | **Alternatives considered** | AWS DocumentDB, self-hosted MongoDB on EC2 |
-| **Rationale** | Free tier eliminates database cost entirely. Fully compatible with MongoEngine (the ORM already used by the app), so no application rewrite is required. |
+| **Rationale** | MongoDB Atlas M0 is a [permanently free tier](https://www.mongodb.com/docs/atlas/reference/free-shared-limitations/) with 512 MB storage, sufficient for a demo. It is fully wire-compatible with MongoEngine (the ORM already in use), so no application changes are required. AWS DocumentDB is only compatible with the MongoDB 4.0 API and starts at ~$50/month; self-hosting on EC2 adds operational overhead and cost with no advantage. |
 
 ---
 
@@ -33,7 +33,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | AWS SSM Parameter Store (Standard tier) |
 | **Alternatives considered** | AWS Secrets Manager, environment variables embedded in the ECS task definition |
-| **Rationale** | Standard-tier parameters are free, versus Secrets Manager at $0.40/secret/month. Embedding secrets in the task definition is insecure and harder to rotate. SSM is adequate for this scale. |
+| **Rationale** | [SSM Parameter Store Standard tier](https://aws.amazon.com/systems-manager/pricing/) is free for up to 10,000 parameters -- the cheapest secure option available. Environment variables embedded directly in an ECS task definition are exposed in plaintext via the ECS API and AWS console, making them visible to any IAM principal with `ecs:DescribeTaskDefinition`. [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) adds automatic rotation and cross-account sharing but costs $0.40/secret/month, which is unnecessary for a short-lived demo. Both `SECRET_KEY` and `MONGO_URI` are stored here: the Atlas connection string embeds credentials (`mongodb+srv://user:password@cluster/`), making it sensitive despite looking like a plain URI. |
 
 ---
 
@@ -43,7 +43,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | GitHub Actions OIDC federation (keyless) |
 | **Alternatives considered** | IAM access keys stored as GitHub Secrets |
-| **Rationale** | No long-lived credentials to rotate or leak. GitHub-native support makes configuration straightforward. Follows AWS and GitHub best-practice guidance for CI/CD authentication. |
+| **Rationale** | [OpenID Connect (OIDC)](https://openid.net/connect/) is an identity layer on top of OAuth 2.0 that lets GitHub Actions prove its identity to AWS IAM using a short-lived token -- no static credentials are stored anywhere. This follows the [AWS IAM best practice of using temporary credentials for workloads](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#bp-workloads-use-roles) and GitHub's [recommended approach for AWS deployments](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services). Long-lived IAM access keys stored as GitHub Secrets are a common source of credential leaks and require manual rotation. |
 
 ---
 
@@ -53,7 +53,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | AWS CDK (Python) |
 | **Alternatives considered** | Terraform, CloudFormation (raw YAML/JSON), AWS SAM |
-| **Rationale** | Same language as the application, so contributors need only one language. CDK provides high-level constructs that reduce boilerplate compared to raw CloudFormation, and `cdk destroy` makes teardown straightforward. |
+| **Rationale** | [Terraform](https://developer.hashicorp.com/terraform) is the more widely adopted IaC tool across the industry (multi-cloud, large ecosystem), but it requires learning HCL in addition to Python. [AWS CDK (Python)](https://docs.aws.amazon.com/cdk/v2/guide/home.html) was chosen because contributors need only one language, and its high-level constructs (e.g. `ecs_patterns.ApplicationLoadBalancedFargateService`) reduce boilerplate significantly versus raw [CloudFormation](https://aws.amazon.com/cloudformation/) YAML. [AWS SAM](https://aws.amazon.com/serverless/sam/) is optimised for Lambda/serverless workloads and is not a natural fit for a long-running Fargate service. The main tradeoff is that CDK is AWS-only and requires Node.js at synth time even for Python apps -- acceptable for a single-cloud demo. `cdk destroy` also makes full teardown of all provisioned resources trivial. |
 
 ---
 
@@ -63,7 +63,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 |---|---|
 | **Decision** | Application Load Balancer (ALB) |
 | **Alternatives considered** | Network Load Balancer (NLB), CloudFront |
-| **Rationale** | ALB provides HTTP/HTTPS routing and integrates natively with ECS service discovery. It is covered by the AWS free tier for the first 12 months (750 hours/month). CloudFront is unnecessary overhead for an internal/demo app. |
+| **Rationale** | ALB provides layer-7 HTTP/HTTPS routing and [integrates natively with ECS service discovery](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html), including health checks and graceful task draining during deployments. The [AWS free tier covers 750 ALB-hours/month for the first 12 months](https://aws.amazon.com/elasticloadbalancing/pricing/), making it effectively free during initial evaluation. NLB operates at layer 4 (TCP) and lacks HTTP-level routing; CloudFront adds CDN caching which provides no benefit for a dynamic Flask app without static asset distribution requirements. |
 
 ---
 
@@ -97,6 +97,17 @@ flowchart TD
 
     ECR -.->|"pulls image"| ECS
 ```
+
+> **Why is `MONGO_URI` a secret?** MongoDB Atlas connection strings embed credentials directly in the URI
+> (e.g. `mongodb+srv://user:password@cluster.mongodb.net/`). Despite looking like a plain address, the URI
+> is sensitive and must not be stored in the ECS task definition, where it would be visible in plaintext
+> via the AWS console and ECS API. Storing it in SSM Standard tier costs nothing.
+>
+> **Why CloudWatch Logs?** CloudWatch is the native log driver for ECS Fargate
+> ([`awslogs` driver](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html))
+> and requires no extra infrastructure or agents. The [free tier](https://aws.amazon.com/cloudwatch/pricing/)
+> covers 5 GB of log ingestion per month -- far more than a low-traffic demo will generate. Alternative
+> aggregators (Datadog, Splunk, Grafana Cloud) all require paid plans at this scale.
 
 ---
 

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,0 +1,156 @@
+# AWS Architecture — Course Enrollment App
+
+This document is the single source of truth for the AWS deployment design of the Course Enrollment App.
+It captures architecture decisions, the system diagram, cost estimates, and the release strategy.
+
+---
+
+## Architecture Decision Records
+
+### ADR-001: Container Orchestration — ECS Fargate
+
+| | |
+|---|---|
+| **Decision** | ECS Fargate |
+| **Alternatives considered** | EC2, EKS, App Runner |
+| **Rationale** | Serverless containers — no EC2 patching, scales to zero when desired count is set to 0 (ideal for demo/cost control), and is the cheapest managed container option at this scale. |
+
+---
+
+### ADR-002: Database — MongoDB Atlas M0
+
+| | |
+|---|---|
+| **Decision** | MongoDB Atlas M0 (free cluster) |
+| **Alternatives considered** | AWS DocumentDB, self-hosted MongoDB on EC2 |
+| **Rationale** | Free tier eliminates database cost entirely. Fully compatible with MongoEngine (the ORM already used by the app), so no application rewrite is required. |
+
+---
+
+### ADR-003: Secrets Management — SSM Parameter Store
+
+| | |
+|---|---|
+| **Decision** | AWS SSM Parameter Store (Standard tier) |
+| **Alternatives considered** | AWS Secrets Manager, environment variables embedded in the ECS task definition |
+| **Rationale** | Standard-tier parameters are free, versus Secrets Manager at $0.40/secret/month. Embedding secrets in the task definition is insecure and harder to rotate. SSM is adequate for this scale. |
+
+---
+
+### ADR-004: GitHub → AWS Authentication — OIDC (Keyless)
+
+| | |
+|---|---|
+| **Decision** | GitHub Actions OIDC federation (keyless) |
+| **Alternatives considered** | IAM access keys stored as GitHub Secrets |
+| **Rationale** | No long-lived credentials to rotate or leak. GitHub-native support makes configuration straightforward. Follows AWS and GitHub best-practice guidance for CI/CD authentication. |
+
+---
+
+### ADR-005: Infrastructure as Code — AWS CDK (Python)
+
+| | |
+|---|---|
+| **Decision** | AWS CDK (Python) |
+| **Alternatives considered** | Terraform, CloudFormation (raw YAML/JSON), AWS SAM |
+| **Rationale** | Same language as the application, so contributors need only one language. CDK provides high-level constructs that reduce boilerplate compared to raw CloudFormation, and `cdk destroy` makes teardown straightforward. |
+
+---
+
+### ADR-006: Load Balancer — Application Load Balancer (ALB)
+
+| | |
+|---|---|
+| **Decision** | Application Load Balancer (ALB) |
+| **Alternatives considered** | Network Load Balancer (NLB), CloudFront |
+| **Rationale** | ALB provides HTTP/HTTPS routing and integrates natively with ECS service discovery. It is covered by the AWS free tier for the first 12 months (750 hours/month). CloudFront is unnecessary overhead for an internal/demo app. |
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    Dev["Developer"]
+    GHA["GitHub Actions\n(CI/CD)"]
+    OIDC["AWS OIDC Provider\n(keyless auth)"]
+    ECR["Amazon ECR\n(container registry)"]
+    ECS["ECS Fargate Task\n(Flask / Gunicorn)"]
+    ALB["Application Load Balancer\n(HTTPS)"]
+    SSM["SSM Parameter Store\n(SECRET_KEY, MONGO_URI)"]
+    CW["CloudWatch Logs"]
+    Atlas["MongoDB Atlas M0\n(external, same region)"]
+    Internet["Internet"]
+
+    Dev -->|"git push / PR merge"| GHA
+    GHA -->|"assume role via"| OIDC
+    OIDC -->|"short-lived token"| GHA
+    GHA -->|"docker push"| ECR
+    GHA -->|"force-new-deployment"| ECS
+
+    Internet -->|"HTTPS"| ALB
+    ALB -->|"HTTP"| ECS
+
+    ECS -->|"reads secrets at startup"| SSM
+    ECS -->|"queries / writes"| Atlas
+    ECS -->|"stdout / stderr"| CW
+
+    ECR -.->|"pulls image"| ECS
+```
+
+---
+
+## Cost Estimate
+
+> All prices are approximate US East (us-east-1) on-demand rates as of 2026.
+
+| Service | Configuration | Est. monthly cost |
+|---|---|---|
+| ECS Fargate | 0.25 vCPU / 0.5 GB RAM, running 24/7 | ~$10 |
+| ALB | Free tier: 750 hrs/month for first 12 months | $0 → ~$16 |
+| ECR | Free tier: 500 MB storage | $0 |
+| SSM Parameter Store | Standard tier | $0 |
+| MongoDB Atlas | M0 free cluster | $0 |
+| CloudWatch Logs | Free tier: 5 GB ingestion/month | $0 |
+| **Total** | | **~$10–26/month** |
+
+> **Cost-saving tip:** Set ECS desired count to `0` when not demoing.
+> This reduces the Fargate charge to ~$0, bringing the total monthly cost to near $0 while retaining all infrastructure.
+
+---
+
+## Release Strategy and Versioning
+
+### Versioning scheme
+
+The project follows [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`):
+
+| Component | When to increment |
+|---|---|
+| `MAJOR` | Breaking changes to the API or data model |
+| `MINOR` | New features added in a backwards-compatible manner |
+| `PATCH` | Backwards-compatible bug fixes |
+
+The current AWS deployment milestone is **v2.0.0**.
+
+### Release process
+
+1. **Feature branch** — all work is done on a branch off `main`.
+1. **Pull request** — PR is opened; CI runs linting, unit tests, and Playwright e2e tests.
+1. **Merge to `main`** — triggers the CD pipeline:
+   - Docker image is built and pushed to ECR, tagged with the Git SHA and the semantic version tag (e.g., `v2.1.0`).
+   - ECS service is updated via `force-new-deployment`; the old task is drained gracefully by the ALB.
+1. **GitHub Release** — a GitHub Release is created from the version tag, auto-generating a changelog from merged PRs.
+
+### Docker image tagging convention
+
+| Tag | Purpose |
+|---|---|
+| `latest` | Most recent build from `main` |
+| `<git-sha>` | Immutable reference to an exact commit |
+| `v<MAJOR.MINOR.PATCH>` | Stable release tag for rollbacks |
+
+### Rollback procedure
+
+To revert a bad deployment, re-tag a previous ECR image as `latest` and trigger a new ECS force-deployment,
+or use the ECS console to point the service at a prior task definition revision.

--- a/docs/aws-architecture.md
+++ b/docs/aws-architecture.md
@@ -1,4 +1,4 @@
-# AWS Architecture — Course Enrollment App
+# AWS Architecture -- Course Enrollment App
 
 This document is the single source of truth for the AWS deployment design of the Course Enrollment App.
 It captures architecture decisions, the system diagram, cost estimates, and the release strategy.
@@ -7,17 +7,17 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 
 ## Architecture Decision Records
 
-### ADR-001: Container Orchestration — ECS Fargate
+### ADR-001: Container Orchestration -- ECS Fargate
 
 | | |
 |---|---|
 | **Decision** | ECS Fargate |
 | **Alternatives considered** | EC2, EKS, App Runner |
-| **Rationale** | Serverless containers — no EC2 patching, scales to zero when desired count is set to 0 (ideal for demo/cost control), and is the cheapest managed container option at this scale. |
+| **Rationale** | Serverless containers -- no EC2 patching, scales to zero when desired count is set to 0 (ideal for demo/cost control), and is the cheapest managed container option at this scale. |
 
 ---
 
-### ADR-002: Database — MongoDB Atlas M0
+### ADR-002: Database -- MongoDB Atlas M0
 
 | | |
 |---|---|
@@ -27,7 +27,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 
 ---
 
-### ADR-003: Secrets Management — SSM Parameter Store
+### ADR-003: Secrets Management -- SSM Parameter Store
 
 | | |
 |---|---|
@@ -37,7 +37,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 
 ---
 
-### ADR-004: GitHub → AWS Authentication — OIDC (Keyless)
+### ADR-004: GitHub → AWS Authentication -- OIDC (Keyless)
 
 | | |
 |---|---|
@@ -47,7 +47,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 
 ---
 
-### ADR-005: Infrastructure as Code — AWS CDK (Python)
+### ADR-005: Infrastructure as Code -- AWS CDK (Python)
 
 | | |
 |---|---|
@@ -57,7 +57,7 @@ It captures architecture decisions, the system diagram, cost estimates, and the 
 
 ---
 
-### ADR-006: Load Balancer — Application Load Balancer (ALB)
+### ADR-006: Load Balancer -- Application Load Balancer (ALB)
 
 | | |
 |---|---|
@@ -112,7 +112,7 @@ flowchart TD
 | SSM Parameter Store | Standard tier | $0 |
 | MongoDB Atlas | M0 free cluster | $0 |
 | CloudWatch Logs | Free tier: 5 GB ingestion/month | $0 |
-| **Total** | | **~$10–26/month** |
+| **Total** | | **~$10-26/month** |
 
 > **Cost-saving tip:** Set ECS desired count to `0` when not demoing.
 > This reduces the Fargate charge to ~$0, bringing the total monthly cost to near $0 while retaining all infrastructure.
@@ -135,12 +135,12 @@ The current AWS deployment milestone is **v2.0.0**.
 
 ### Release process
 
-1. **Feature branch** — all work is done on a branch off `main`.
-1. **Pull request** — PR is opened; CI runs linting, unit tests, and Playwright e2e tests.
-1. **Merge to `main`** — triggers the CD pipeline:
+1. **Feature branch** -- all work is done on a branch off `main`.
+1. **Pull request** -- PR is opened; CI runs linting, unit tests, and Playwright e2e tests.
+1. **Merge to `main`** -- triggers the CD pipeline:
    - Docker image is built and pushed to ECR, tagged with the Git SHA and the semantic version tag (e.g., `v2.1.0`).
    - ECS service is updated via `force-new-deployment`; the old task is drained gracefully by the ALB.
-1. **GitHub Release** — a GitHub Release is created from the version tag, auto-generating a changelog from merged PRs.
+1. **GitHub Release** -- a GitHub Release is created from the version tag, auto-generating a changelog from merged PRs.
 
 ### Docker image tagging convention
 


### PR DESCRIPTION
## Overview

Closes #50

Creates `docs/aws-architecture.md` as the single source of truth for the AWS deployment design, and updates the markdownlint configuration to correctly handle long table cells.

## Changes

### `docs/aws-architecture.md` (new)

- **6 Architecture Decision Records (ADRs)** covering each major technology choice: ECS Fargate, MongoDB Atlas M0, SSM Parameter Store, OIDC keyless auth, AWS CDK (Python), and ALB.
- **Mermaid architecture diagram** showing all data flows: Internet → ALB → ECS Fargate, ECS → MongoDB Atlas, ECS → SSM Parameter Store, ECS → CloudWatch Logs, GitHub Actions → ECR, GitHub Actions → ECS, and Developer → GitHub Actions via OIDC.
- **Cost estimate table** (estimated ~$10–26/month), including a tip to set ECS desired count to `0` to reduce cost to ~$0 when not demoing.
- **Release strategy** covering semver conventions, the PR → merge → deploy pipeline, Docker image tagging (`latest`, git SHA, version tag), and rollback procedure.

### `.markdownlint.rb` / `.markdownlint.yaml`

- Added `:tables => false` / `tables: false` to the MD013 rule so that long table cell content is exempt from the 120-character line-length limit. Table cells cannot be wrapped in standard Markdown, making this the correct opt-out rather than per-line disable comments.