### PR TITLE
fix: adds rate limiting, email validation, password max [#53]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@
   `pre-commit run --files <changed files>`.
 - For route, model, form, or shared behavior changes, run `pytest`.
 - For CI-equivalent Python validation, run
-  `pytest --cov=application --cov-report=term-missing --cov-fail-under=100`.
+  `pytest --cov=application --cov-report=term-missing --cov-fail-under=100`
+  or `make codecov`.
 - For formatting and linting across the repo, run `pre-commit run --all-files`
   or `make lint`.
 - For Docker/local stack verification, use `make setup`, `make run`, and

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,5 +1,7 @@
 import mongoengine
 from flask import Flask
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_restx import Api
 from flask_wtf.csrf import CSRFProtect
 
@@ -8,9 +10,14 @@ from config import get_config_for_env
 # initiate the main web app
 app = Flask(__name__)
 app.config.from_object(get_config_for_env())
+app.config.setdefault("RATELIMIT_STORAGE_URI", "memory://")
 
 # enable CSRF protection for all POST forms
 csrf = CSRFProtect(app)
+
+# rate limit authentication POSTs without requiring extra infra in development
+limiter = Limiter(key_func=get_remote_address)
+limiter.init_app(app)
 
 # initiate the mongo engine
 mongoengine.connect(

--- a/application/forms.py
+++ b/application/forms.py
@@ -15,20 +15,20 @@ from application.models import User
 class LoginForm(FlaskForm):
     email = StringField("Email", validators=[DataRequired(), Email()])
     password = PasswordField(
-        "Password", validators=[DataRequired(), Length(min=6, max=15)]
+        "Password", validators=[DataRequired(), Length(min=8, max=128)]
     )
     remember_me = BooleanField("Remember Me")
     submit = SubmitField("Login")
 
 
 class RegisterForm(FlaskForm):
-    email = StringField("Email", validators=[DataRequired()])
+    email = StringField("Email", validators=[DataRequired(), Email()])
     password = PasswordField(
-        "Password", validators=[DataRequired(), Length(min=6, max=15)]
+        "Password", validators=[DataRequired(), Length(min=8, max=128)]
     )
     password_confirm = PasswordField(
         "Confirm Password",
-        validators=[DataRequired(), Length(min=6, max=15), EqualTo("password")],
+        validators=[DataRequired(), Length(min=8, max=128), EqualTo("password")],
     )
     first_name = StringField(
         "First Name", validators=[DataRequired(), Length(min=2, max=55)]
@@ -39,8 +39,7 @@ class RegisterForm(FlaskForm):
     submit = SubmitField("Register Now")
 
     def validate_email(self, email):
-        # this throws an error for some reason
         user = User.objects(email=email.data)
         user = user.first()
         if user:
-            raise ValidationError("Email is already in user. Pick another one.")
+            raise ValidationError("Email is already in use. Pick another one.")

--- a/application/forms.py
+++ b/application/forms.py
@@ -42,4 +42,4 @@ class RegisterForm(FlaskForm):
         user = User.objects(email=email.data)
         user = user.first()
         if user:
-            raise ValidationError("Email is already in use. Pick another one.")
+            raise ValidationError("Registration failed. Please check your details.")

--- a/application/routes.py
+++ b/application/routes.py
@@ -15,6 +15,7 @@ from flask_restx import Resource
 
 from application import api
 from application import app
+from application import limiter
 from application.course_list import course_list_for_user
 from application.forms import LoginForm
 from application.forms import RegisterForm
@@ -83,6 +84,7 @@ def index():
 
 
 @app.route("/login", methods=["GET", "POST"])
+@limiter.limit("5 per minute", methods=["POST"])
 def login():
     """Returns the login page content."""
     if session.get("username"):
@@ -123,6 +125,7 @@ def courses(term=None):
 
 
 @app.route("/register", methods=["POST", "GET"])
+@limiter.limit("5 per minute", methods=["POST"])
 def register():
     """Returns the registration page content."""
     if session.get("username"):

--- a/application/routes.py
+++ b/application/routes.py
@@ -12,6 +12,7 @@ from flask import send_from_directory
 from flask import session
 from flask import url_for
 from flask_restx import Resource
+from mongoengine.errors import NotUniqueError
 
 from application import api
 from application import app
@@ -34,6 +35,36 @@ def login_required_api(f):
         return f(*args, **kwargs)
 
     return wrapper
+
+
+###################################################
+
+
+def _next_user_id():
+    latest_user = User.objects.only("user_id").order_by("-user_id").first()
+    if latest_user is None or latest_user.user_id is None:
+        return 1
+    return latest_user.user_id + 1
+
+
+def _register_user(email, password, first_name, last_name, max_attempts=5):
+    for _ in range(max_attempts):
+        user = User(
+            user_id=_next_user_id(),
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        user.set_password(password)
+        try:
+            user.save()
+        except NotUniqueError:
+            # Another registration won the same user_id or email race; retry safely.
+            if User.objects(email=email).first():
+                return None
+            continue
+        return user
+    return None
 
 
 ###################################################
@@ -107,7 +138,7 @@ def login():
     return render_template("login.html", title="Login", form=form, login=True)
 
 
-@app.route("/logout")
+@app.route("/logout", methods=["POST"])
 def logout():
     session.clear()
     return redirect(url_for("index"))
@@ -132,17 +163,16 @@ def register():
         return redirect(url_for("index"))
     form = RegisterForm()
     if form.validate_on_submit():
-        user_id = User.objects.count()
-        user_id += 1
         email = form.email.data
         password = form.password.data
         first_name = form.first_name.data
         last_name = form.last_name.data
-        user = User(
-            user_id=user_id, email=email, first_name=first_name, last_name=last_name
-        )
-        user.set_password(password)
-        user.save()
+        user = _register_user(email, password, first_name, last_name)
+        if not user:
+            flash("Registration failed. Please check your details.", "danger")
+            return render_template(
+                "register.html", title="Register", form=form, register=True
+            )
         flash("You are successfully registered!", "success")
         return redirect(url_for("index"))
     return render_template("register.html", title="Register", form=form, register=True)
@@ -155,22 +185,25 @@ def enrollment():
         return redirect(url_for("login"))
 
     courseID = request.form.get("courseID")
-    courseTitle = request.form.get("title")
     user_id = session.get("user_id")
 
     # we check if we're coming from the course page here
     # if there's a courseID, it means we're enrolling in a course
     if courseID:
+        course = Course.objects(courseID=courseID).first()
+        if not course:
+            flash("Course not found.", "danger")
+            return redirect(url_for("enrollment"))
         if Enrollment.objects(user_id=user_id, courseID=courseID):
             flash(
-                f"Oops! You are already registered in course {courseTitle}!",
+                f"Oops! You are already registered in course {course.title}!",
                 "danger",
             )
             return redirect(url_for("courses"))
         else:
             enrollment = Enrollment(user_id=user_id, courseID=courseID)
             enrollment.save()
-            flash(f"You are enrolled in {courseTitle}!", "success")
+            flash(f"You are enrolled in {course.title}!", "success")
 
     courses = course_list_for_user(user_id)
     return render_template(

--- a/application/templates/includes/nav.html
+++ b/application/templates/includes/nav.html
@@ -10,7 +10,12 @@
             {% if not session["username"] %}
                 <li class="nav-item"><a href="{{ url_for('login') }}" class="nav-link {% if login %}active{% endif %}">Login</a></li>
             {% else %}
-                <li class="nav-item"><a href="{{ url_for('logout') }}" class="nav-link {% if logout %}active{% endif %}">Logout</a></li>
+                <li class="nav-item">
+                    <form action="{{ url_for('logout') }}" method="post" class="d-inline">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="nav-link {% if logout %}active{% endif %} border-0 bg-transparent">Logout</button>
+                    </form>
+                </li>
             {% endif %}
         </ul>
     </nav>

--- a/e2e/ui-walkthrough.spec.js
+++ b/e2e/ui-walkthrough.spec.js
@@ -50,7 +50,7 @@ test('UI walkthrough from TESTING.md', async ({ page }) => {
   await expect(page).toHaveURL(/\/index$/);
   await expect(page.getByRole('link', { name: 'Register' })).toHaveCount(0);
   await expect(page.getByRole('link', { name: 'Login' })).toHaveCount(0);
-  await expect(page.getByRole('link', { name: 'Logout' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible();
 
   // 7. Authenticated API access: course list is accessible when logged in.
   await page.goto('/api/v1/courses');
@@ -72,7 +72,7 @@ test('UI walkthrough from TESTING.md', async ({ page }) => {
 
   // 11. Logout and verify logged-out state.
   await page.goto('/index');
-  await page.getByRole('link', { name: 'Logout' }).click();
+  await page.getByRole('button', { name: 'Logout' }).click();
   await expect(page).toHaveURL(/\/index$/);
   await expect(page.locator('nav').getByRole('link', { name: 'Login' })).toBeVisible();
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 email-validator==2.3.0
+Flask-Limiter==4.1.1
 flask-restx==1.3.2
 Flask-WTF==1.2.2
 Flask==3.1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-do-not-use-in-production")
 
 # Delayed imports are required: app initialization reads env/path at import-time.
 from application import app  # noqa: E402
+from application import limiter  # noqa: E402
 from application.models import Course  # noqa: E402
 from application.models import Enrollment  # noqa: E402
 from application.models import User  # noqa: E402
@@ -46,7 +47,10 @@ def _reset_collections():
 def test_app():
     app.config.update(
         WTF_CSRF_ENABLED=False,
+        RATELIMIT_ENABLED=False,
     )
+    limiter.reset()
+    limiter.enabled = False
     return app
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,4 @@
+from application import limiter
 from application.models import Enrollment
 from application.models import User
 
@@ -7,6 +8,15 @@ def _session_cookie_header(response):
         if header.startswith("session="):
             return header
     raise AssertionError("Expected a session cookie in the response")
+
+
+def _post_from_ip(client, path, data, remote_addr, follow_redirects=False):
+    return client.post(
+        path,
+        data=data,
+        follow_redirects=follow_redirects,
+        environ_overrides={"REMOTE_ADDR": remote_addr},
+    )
 
 
 def test_index_page_loads(client):
@@ -70,6 +80,73 @@ def test_register_creates_user_and_redirects(client):
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/index")
     assert User.objects(email="newuser@example.com").count() == 1
+
+
+def test_register_requires_valid_email_address(client):
+    response = client.post(
+        "/register",
+        data={
+            "email": "not-an-email",
+            "password": "secret123",
+            "password_confirm": "secret123",
+            "first_name": "New",
+            "last_name": "User",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert b"Invalid email address." in response.data
+    assert User.objects(email="not-an-email").count() == 0
+
+
+def test_register_rejects_passwords_shorter_than_eight_characters(client):
+    response = client.post(
+        "/register",
+        data={
+            "email": "newuser@example.com",
+            "password": "abc1234",
+            "password_confirm": "abc1234",
+            "first_name": "New",
+            "last_name": "User",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert b"Field must be between 8 and 128 characters long." in response.data
+    assert User.objects(email="newuser@example.com").count() == 0
+
+
+def test_register_and_login_accept_long_passwords(client):
+    long_password = "correct-horse-battery-staple-with-extra-entropy-1234567890"
+
+    register_response = client.post(
+        "/register",
+        data={
+            "email": "longpass@example.com",
+            "password": long_password,
+            "password_confirm": long_password,
+            "first_name": "Long",
+            "last_name": "Pass",
+        },
+        follow_redirects=False,
+    )
+
+    assert register_response.status_code == 302
+    assert register_response.headers["Location"].endswith("/index")
+
+    login_response = client.post(
+        "/login",
+        data={
+            "email": "longpass@example.com",
+            "password": long_password,
+        },
+        follow_redirects=False,
+    )
+
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"].endswith("/index")
 
 
 def test_login_success_sets_session_and_redirects(client, registered_user):
@@ -161,6 +238,37 @@ def test_login_failure_shows_error(client, registered_user):
 
     assert response.status_code == 200
     assert b"Sorry, something went wrong." in response.data
+
+
+def test_login_rate_limits_post_attempts(client, monkeypatch, registered_user):
+    limiter.reset()
+    monkeypatch.setattr(limiter, "enabled", True)
+
+    for _ in range(5):
+        response = _post_from_ip(
+            client,
+            "/login",
+            data={
+                "email": registered_user.email,
+                "password": "wrongpass",
+            },
+            remote_addr="198.51.100.10",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+
+    response = _post_from_ip(
+        client,
+        "/login",
+        data={
+            "email": registered_user.email,
+            "password": "wrongpass",
+        },
+        remote_addr="198.51.100.10",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 429
 
 
 def test_enrollment_requires_login(client):
@@ -263,6 +371,43 @@ def test_register_duplicate_email_renders_form_with_error(client, registered_use
 
     assert response.status_code == 200
     assert b"Email is already in user" in response.data
+
+
+def test_register_rate_limits_post_attempts(client, monkeypatch):
+    limiter.reset()
+    monkeypatch.setattr(limiter, "enabled", True)
+
+    for _ in range(5):
+        response = _post_from_ip(
+            client,
+            "/register",
+            data={
+                "email": "not-an-email",
+                "password": "secret123",
+                "password_confirm": "secret123",
+                "first_name": "Rate",
+                "last_name": "Limited",
+            },
+            remote_addr="198.51.100.11",
+            follow_redirects=False,
+        )
+        assert response.status_code == 200
+
+    response = _post_from_ip(
+        client,
+        "/register",
+        data={
+            "email": "not-an-email",
+            "password": "secret123",
+            "password_confirm": "secret123",
+            "first_name": "Rate",
+            "last_name": "Limited",
+        },
+        remote_addr="198.51.100.11",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 429
 
 
 def test_favicon_returns_icon(client):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,4 +1,7 @@
+from mongoengine.errors import NotUniqueError
+
 from application import limiter
+from application import routes as routes_module
 from application.models import Enrollment
 from application.models import User
 
@@ -294,6 +297,22 @@ def test_enrollment_creates_record_for_logged_in_user(logged_in_client, seed_cou
     assert Enrollment.objects(user_id=1, courseID="CSE100").count() == 1
 
 
+def test_enrollment_rejects_unknown_course(logged_in_client):
+    response = logged_in_client.post(
+        "/enrollment",
+        data={
+            "courseID": "NOPE999",
+            "title": "Ghost Course",
+            "term": "Fall 2026",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Course not found." in response.data
+    assert Enrollment.objects(user_id=1, courseID="NOPE999").count() == 0
+
+
 def test_duplicate_enrollment_shows_error(logged_in_client, seed_courses):
     Enrollment(user_id=1, courseID="CSE100").save()
 
@@ -322,7 +341,7 @@ def test_logout_clears_session_and_redirects(logged_in_client):
     with logged_in_client.session_transaction() as session:
         session["extra_key"] = "leftover"
 
-    response = logged_in_client.get("/logout", follow_redirects=False)
+    response = logged_in_client.post("/logout", follow_redirects=False)
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/index")
@@ -333,6 +352,12 @@ def test_logout_clears_session_and_redirects(logged_in_client):
     response = logged_in_client.get("/enrollment", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/login")
+
+
+def test_logout_rejects_get_requests(client):
+    response = client.get("/logout", follow_redirects=False)
+
+    assert response.status_code == 405
 
 
 def test_login_redirects_when_already_logged_in(logged_in_client):
@@ -370,7 +395,92 @@ def test_register_duplicate_email_renders_form_with_error(client, registered_use
     )
 
     assert response.status_code == 200
-    assert b"Email is already in user" in response.data
+    assert b"Registration failed. Please check your details." in response.data
+    assert b"Email is already in use" not in response.data
+
+
+def test_register_user_returns_none_for_duplicate_email(registered_user):
+    result = routes_module._register_user(
+        registered_user.email, "secret123", "Repeat", "User"
+    )
+
+    assert result is None
+    assert User.objects(email=registered_user.email).count() == 1
+
+
+def test_register_retries_when_user_id_save_conflicts(
+    client, monkeypatch, registered_user
+):
+    original_save = User.save
+    raised_duplicate = {"value": False}
+
+    def save_with_one_conflict(self, *args, **kwargs):
+        if self.email == "retry@example.com" and not raised_duplicate["value"]:
+            raised_duplicate["value"] = True
+            raise NotUniqueError("duplicate unique key")
+        return original_save(self, *args, **kwargs)
+
+    monkeypatch.setattr(User, "save", save_with_one_conflict)
+
+    response = client.post(
+        "/register",
+        data={
+            "email": "retry@example.com",
+            "password": "secret123",
+            "password_confirm": "secret123",
+            "first_name": "Retry",
+            "last_name": "User",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/index")
+    assert User.objects(email="retry@example.com").count() == 1
+    assert User.objects.get(email="retry@example.com").user_id == 2
+    assert raised_duplicate["value"] is True
+
+
+def test_register_user_returns_none_after_exhausting_conflict_retries(monkeypatch):
+    attempts = {"count": 0}
+
+    def always_conflict(self, *args, **kwargs):
+        attempts["count"] += 1
+        raise NotUniqueError("duplicate unique key")
+
+    monkeypatch.setattr(User, "save", always_conflict)
+
+    result = routes_module._register_user(
+        "stuck@example.com",
+        "secret123",
+        "Retry",
+        "Loop",
+        max_attempts=2,
+    )
+
+    assert result is None
+    assert attempts["count"] == 2
+    assert User.objects(email="stuck@example.com").count() == 0
+
+
+def test_register_shows_generic_error_when_user_creation_fails(client, monkeypatch):
+    monkeypatch.setattr(routes_module, "_register_user", lambda *args, **kwargs: None)
+
+    response = client.post(
+        "/register",
+        data={
+            "email": "failing@example.com",
+            "password": "secret123",
+            "password_confirm": "secret123",
+            "first_name": "Failing",
+            "last_name": "User",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert b"Registration failed. Please check your details." in response.data
+    assert User.objects(email="failing@example.com").count() == 0
 
 
 def test_register_rate_limits_post_attempts(client, monkeypatch):


### PR DESCRIPTION
## Summary

- harden the authentication flow with `Flask-Limiter` rate limits on `POST /login` and `POST /register`
- require a valid email address during registration and expand password support to `8-128` characters
- replace duplicate-email feedback with a generic registration failure message to reduce user enumeration
- remove the `user_id = count() + 1` race by retrying registration on unique-key conflicts while preserving the existing `user_id`-based schema
- validate that a submitted `courseID` exists before creating an enrollment
- make `/logout` `POST`-only and move the nav logout action to a CSRF-protected form
- expand route and Playwright coverage and keep the branch at `100%` Python coverage

## Notes

- This keeps the current `user_id`-based enrollment/session flow intact instead of migrating the app to Mongo `_id`, which avoids a larger schema and seed-data change while still addressing the registration race condition.
- The Playwright walkthrough was updated to use the new logout button behavior.

## Testing

- `docker compose exec course-enrollment-app python -m pytest`
- `docker compose run --rm e2e-tests`
- `pre-commit run --files application/__init__.py application/forms.py application/routes.py tests/conftest.py tests/test_routes.py requirements.txt`
- `pre-commit run --files application/forms.py application/routes.py application/templates/includes/nav.html tests/test_routes.py e2e/ui-walkthrough.spec.js`
- `pre-commit run --files tests/test_routes.py AGENTS.md`
- `make codecov`

Closes #53
