### PR TITLE
feat: support Atlas seeding via MONGO_URI [#56]

### DIFF
--- a/mongo-setup/mongo-setup.sh
+++ b/mongo-setup/mongo-setup.sh
@@ -1,30 +1,43 @@
 #!/usr/bin/env bash
-set -e
-HOST=mongodb            # Taken from docker-compose
-DB=NOU_Enrollment       # Taken from config.py
-MOUNT_PATH=/mongo-setup # Taken from docker-compose
+set -euo pipefail
+
+HOST="${HOST:-mongodb}"          # Default for local docker-compose
+DB="${DB:-NOU_Enrollment}"
+MOUNT_PATH="${MOUNT_PATH:-/mongo-setup}"
 
 seed_collection() {
   local collection="$1"
   local json_file_path="$2"
   echo "Setting up ${DB} db with ${collection} collection from ${json_file_path}..."
-  mongoimport \
-    --host "${HOST}" \
-    --db "${DB}" \
-    --collection "${collection}" \
-    --type json \
-    --file "${json_file_path}" \
-    --jsonArray \
-    --drop
+  if [[ -n "${MONGO_URI:-}" ]]; then
+    mongoimport \
+      --uri "${MONGO_URI}" \
+      --collection "${collection}" \
+      --type json \
+      --file "${json_file_path}" \
+      --jsonArray \
+      --drop
+  else
+    mongoimport \
+      --host "${HOST}" \
+      --db "${DB}" \
+      --collection "${collection}" \
+      --type json \
+      --file "${json_file_path}" \
+      --jsonArray \
+      --drop
+  fi
   echo "Done setting ${collection} collection."
 }
 
 drop_collection() {
   local collection="$1"
   echo "Dropping stale ${collection} data..."
-
-  mongosh --host "${HOST}" --eval "db.getSiblingDB('${DB}').${collection}.drop()"
-
+  if [[ -n "${MONGO_URI:-}" ]]; then
+    mongosh "${MONGO_URI}" --eval "db.${collection}.drop()"
+  else
+    mongosh --host "${HOST}" --eval "db.getSiblingDB('${DB}').${collection}.drop()"
+  fi
   echo "Done dropping ${collection} collection."
 }
 

--- a/mongo-setup/mongo-setup.sh
+++ b/mongo-setup/mongo-setup.sh
@@ -19,9 +19,15 @@ seed_collection() {
   echo "Done setting ${collection} collection."
 }
 
+drop_collection() {
+  local collection="$1"
+  echo "Dropping stale ${collection} data..."
+
+  mongosh --host "${HOST}" --eval "db.getSiblingDB('${DB}').${collection}.drop()"
+
+  echo "Done dropping ${collection} collection."
+}
+
 seed_collection "user"   "${MOUNT_PATH}/users.json"
 seed_collection "course" "${MOUNT_PATH}/courses.json"
-
-echo "Dropping stale enrollment data..."
-mongosh --host "${HOST}" --eval "db.getSiblingDB('${DB}').enrollment.drop()"
-echo "Done dropping enrollment collection."
+drop_collection "enrollment"

--- a/mongo-setup/mongo-setup.sh
+++ b/mongo-setup/mongo-setup.sh
@@ -8,13 +8,14 @@ seed_collection() {
   local collection="$1"
   local json_file_path="$2"
   echo "Setting up ${DB} db with ${collection} collection from ${json_file_path}..."
-  mongoimport --host "${HOST}" \
-              --db "${DB}" \
-              --collection "${collection}" \
-              --type json \
-              --file "${json_file_path}" \
-              --jsonArray \
-              --drop
+  mongoimport \
+    --host "${HOST}" \
+    --db "${DB}" \
+    --collection "${collection}" \
+    --type json \
+    --file "${json_file_path}" \
+    --jsonArray \
+    --drop
   echo "Done setting ${collection} collection."
 }
 


### PR DESCRIPTION
## Summary

- update `mongo-setup/mongo-setup.sh` to support seeding via external `MONGO_URI`
- preserve the existing local Docker fallback to `mongodb`
- refactor stale enrollment cleanup into a reusable helper

## Why

This enables the seed script to target MongoDB Atlas for Issue #56 without breaking the current local Docker workflow.

## Validation

- ran the updated seed script against MongoDB Atlas using the `app-user` SRV URI
- confirmed `user` and `course` collections imported successfully
- confirmed stale `enrollment` collection was dropped