### PR TITLE
ci: enables deployment to AWS ECS [#59]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,86 @@ jobs:
       - name: Stop services
         if: always()
         run: docker compose down --remove-orphans
+
+  deploy:
+    name: Deploy to AWS ECS
+    runs-on: ubuntu-latest
+    needs: [lint, test, docker-build, e2e-docker]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: ${{ vars.AWS_REGION }}
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+      ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+      ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+      IMAGE_TAG: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Validate deploy configuration
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          : "${AWS_ROLE_ARN:?Missing GitHub secret AWS_ROLE_ARN}"
+          : "${AWS_REGION:?Missing GitHub variable AWS_REGION}"
+          : "${ECR_REGISTRY:?Missing GitHub variable ECR_REGISTRY}"
+          : "${ECR_REPOSITORY:?Missing GitHub variable ECR_REPOSITORY}"
+          : "${ECS_CLUSTER:?Missing GitHub variable ECS_CLUSTER}"
+          : "${ECS_SERVICE:?Missing GitHub variable ECS_SERVICE}"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        env:
+          IMAGE_URI: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+        run: |
+          docker build -t "$IMAGE_URI" .
+          docker push "$IMAGE_URI"
+
+      - name: Load current ECS task definition
+        id: task-def
+        run: |
+          CURRENT_TASK_DEF_ARN="$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].taskDefinition' \
+            --output text)"
+          aws ecs describe-task-definition \
+            --task-definition "$CURRENT_TASK_DEF_ARN" \
+            --query taskDefinition \
+            > task-definition-full.json
+          jq 'del(
+            .taskDefinitionArn,
+            .revision,
+            .status,
+            .requiresAttributes,
+            .compatibilities,
+            .registeredAt,
+            .registeredBy
+          )' task-definition-full.json > task-definition.json
+          echo "container_name=$(jq -r '.containerDefinitions[0].name' task-definition.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Render new ECS task definition
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ steps.task-def.outputs.container_name }}
+          image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true


### PR DESCRIPTION
## Summary

Adds the Phase 5 CD pipeline to `.github/workflows/main.yml` so merges to `main` can deploy the app to AWS ECS after the existing CI jobs succeed.

This PR extends the current GitHub Actions workflow with a `deploy` job that:
- runs only on `push` to `main`
- waits for `lint`, `test`, `docker-build`, and `e2e-docker`
- authenticates to AWS with GitHub OIDC via `AWS_ROLE_ARN`
- builds and pushes a Docker image to ECR tagged with `github.sha`
- reads the current ECS task definition, updates the container image, registers a new task definition revision, and deploys it to `course-enrollment-app-svc`
- waits for ECS service stability before marking the workflow green

## Why this approach

The deployment uses immutable SHA image tags instead of reusing `latest`.
That gives us commit-to-runtime traceability and fits the current AWS setup, where the ECR repository was created with tag immutability enabled in Phase 1.

## GitHub Actions configuration

This PR expects the following repo configuration:

### Secret
- `AWS_ROLE_ARN`

### Variables
- `AWS_REGION`
- `ECR_REGISTRY`
- `ECR_REPOSITORY`
- `ECS_CLUSTER`
- `ECS_SERVICE`

These values have already been added in GitHub repo settings.

## AWS prerequisite

The GitHub Actions deploy role must be able to:
- describe ECS services
- describe task definitions
- register task definitions
- update the ECS service
- pass `ECSTaskExecutionRole-CourseEnrollmentApp`

The IAM policy for `GitHubActions-CourseEnrollmentApp` was updated to support this deploy flow.

## Validation

Ran locally:
- `pre-commit run --files .github/workflows/main.yml` ✅

Confirmed in GitHub repo settings:
- `gh variable list --repo robert-7/course-enrollment-app` ✅
- `gh secret list --repo robert-7/course-enrollment-app` ✅

## Post-merge validation

After merging this PR to `main`, validate that:
- the `deploy` job runs after the CI jobs pass
- the image is pushed to ECR with the merge commit SHA tag
- ECS creates a new task definition revision and updates `course-enrollment-app-svc`
- the workflow waits successfully for service stability
- CloudWatch logs show the new container starting cleanly
- the ALB `/index` path still returns HTTP 200

Closes #59
