### PR TITLE
fix: enables https and job fixes [#70]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:  # yamllint disable-line rule:truthy
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Temporarily force JavaScript-based GitHub Actions onto Node 24 so we catch
+# compatibility issues before GitHub's hosted runners remove Node 20 entirely.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
@@ -16,7 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6.2.0
-      - uses: pre-commit/action@v3.0.1
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: requirements-dev.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Run linters
+        run: pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest
@@ -25,6 +39,8 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: requirements-dev.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "makefile.configureOnOpen": false
 }

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -4,6 +4,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_restx import Api
 from flask_wtf.csrf import CSRFProtect
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from config import get_config_for_env
 
@@ -11,6 +12,8 @@ from config import get_config_for_env
 app = Flask(__name__)
 app.config.from_object(get_config_for_env())
 app.config.setdefault("RATELIMIT_STORAGE_URI", "memory://")
+# Trust the ALB's forwarded scheme/host so Flask generates HTTPS-aware URLs.
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
 
 # enable CSRF protection for all POST forms
 csrf = CSRFProtect(app)

--- a/application/templates/layout.html
+++ b/application/templates/layout.html
@@ -6,12 +6,12 @@
     <title>Network Operations University - Course Enrollment</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
           integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
-    <link rel="stylesheet" href="{{ url_for('static', filename='/css/main.css') }}"/>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}"/>
 </head>
 <body>
 
 <div class="container-fluid top-container d-flex align-items-center justify-content-center">
-    <img src="{{ url_for('static', filename='/images/nou-logo-200.png') }}">
+    <img src="{{ url_for('static', filename='images/nou-logo-200.png') }}">
     {% if session["username"] %}
         <span class="user">Welcome, {{ session["username"] }}</span>
     {% endif %}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from application import app
 from config import DevelopmentConfig
@@ -17,6 +18,7 @@ def test_application_bootstrap_uses_testing_config():
     assert app.config["TESTING"] is True
     assert app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
     assert app.config["SESSION_COOKIE_SECURE"] is False
+    assert isinstance(app.wsgi_app, ProxyFix)
 
 
 def test_get_config_for_env_defaults_to_development(monkeypatch):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,6 +28,14 @@ def test_index_page_loads(client):
     assert response.status_code == 200
 
 
+def test_index_uses_normalized_static_asset_paths(client):
+    response = client.get("/index")
+
+    assert b'href="/static/css/main.css"' in response.data
+    assert b'src="/static/images/nou-logo-200.png"' in response.data
+    assert b"/static//" not in response.data
+
+
 def test_home_page_loads(client):
     response = client.get("/home")
 


### PR DESCRIPTION
## Summary

Addresses the issues discussed in #70 around two separate areas:

1. GitHub Actions warnings and job setup
2. Production HTTPS / asset loading behavior behind the AWS ALB

This PR contains the repo-side fixes needed to support the AWS HTTPS rollout and to clean up the CI workflow.

## Discussion Summary

During investigation, we confirmed a few separate problems:

- GitHub Actions was warning about JavaScript actions still running on the deprecated Node.js 20 runtime.
- The `lint` job was also relying on an implicit Python version and the `pre-commit/action` wrapper.
- Production POST behavior was failing under the original HTTP-only ALB setup because the app correctly uses secure cookies in `APP_ENV=production`.
- After enabling HTTPS on AWS, the app still showed partial styling issues.
- Browser inspection showed the rendered page included `/static//css/main.css`, and the browser console showed blocked stylesheet requests.
- That pointed to two repo-side issues:
  - doubled static asset paths in the shared layout template
  - Flask not trusting the ALB's forwarded scheme/host headers, so proxy-aware HTTPS behavior was incomplete

Separately from this PR, the AWS and DNS side was configured manually during the discussion:
- an ACM certificate was requested and DNS-validated via Namecheap
- `course-enrollment-app.robertlech.com` was pointed at the ALB
- the ALB was updated to serve HTTPS and redirect HTTP to HTTPS

## What This PR Changes

### CI / workflow fixes
- Updates `.github/workflows/main.yml` to set `python-version: 3.13` in the `lint` job
- Replaces `pre-commit/action` with explicit dependency installation plus `pre-commit run --all-files`
- Enables pip caching for the Python jobs
- Temporarily sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` for the workflow, with an inline comment explaining that this is a compatibility guardrail while GitHub-hosted runners complete the Node 20 deprecation transition

### HTTPS / app fixes
- Wraps the Flask app with `ProxyFix` in `application/__init__.py` so the app respects the ALB's forwarded scheme/host headers
- Fixes static asset paths in `application/templates/layout.html` by removing the leading slash from `url_for('static', filename=...)`
- This normalizes rendered asset URLs from `/static//...` to `/static/...` and avoids proxy/mixed-content style failures after the HTTPS rollout

### Tests
- Adds a config assertion that the app is wrapped with `ProxyFix`
- Adds a route regression test that verifies index renders normalized static asset paths and does not emit `/static//...`

## Files Changed

- `.github/workflows/main.yml`
- `application/__init__.py`
- `application/templates/layout.html`
- `tests/test_config.py`
- `tests/test_routes.py`
- `.vscode/settings.json`

## Validation

Ran locally:
- `pre-commit run --files application/__init__.py application/templates/layout.html tests/test_config.py tests/test_routes.py` ✅
- `.venv/bin/pytest tests/test_config.py tests/test_routes.py` ✅
- `pre-commit run --files .github/workflows/main.yml` ✅

Validated during the AWS/HTTPS rollout discussion:
- ACM DNS validation CNAME resolved publicly
- `course-enrollment-app.robertlech.com` resolved to the ALB
- ACM certificate reached `ISSUED`
- `https://course-enrollment-app.robertlech.com/index` became reachable through the ALB

## Follow-up After Merge

After this PR is merged and deployed, validate that:
- the GitHub Actions warnings are reduced/cleared as expected
- `https://course-enrollment-app.robertlech.com/index` loads with the app stylesheet applied
- page source renders `/static/css/main.css` rather than `/static//css/main.css`
- registration/login/enrollment POST flows work correctly over HTTPS

Closes #70
